### PR TITLE
Fix failing App.test

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText('モルックスコア管理');
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update test to check for the main heading instead of the old Learn React link

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684cea300c44833288d51f5105281266